### PR TITLE
Build fixes

### DIFF
--- a/XMPCore/source/ExpatAdapter.cpp
+++ b/XMPCore/source/ExpatAdapter.cpp
@@ -146,7 +146,7 @@ void ExpatAdapter::ParseBuffer ( const void * buffer, size_t length, bool last /
 	
 	#if BanAllEntityUsage
 		if ( this->isAborted ) {
-			XMP_Error error(kXMPErr_BadXML, "DOCTYPE is not allowed" )
+			XMP_Error error(kXMPErr_BadXML, "DOCTYPE is not allowed" );
 			this->NotifyClient ( kXMPErrSev_Recoverable, error );
 		}
 	#endif

--- a/XMPFiles/source/FormatSupport/ID3_Support.cpp
+++ b/XMPFiles/source/FormatSupport/ID3_Support.cpp
@@ -871,7 +871,7 @@ void ID3v1Tag::write ( XMP_IO* file, SXMPMeta* meta )
 
 	}
 
-	if ( meta->GetProperty ( kXMP_NS_DM, "trackNumber", &utf8, kXMP_NoOptions ) ) {
+	if ( meta->GetProperty ( kXMP_NS_DM, "trackNumber", &utf8, 0 ) ) {
 
 		XMP_Uns8 trackNo = 0;
 		try {

--- a/XMPFiles/source/FormatSupport/RIFF_Support.cpp
+++ b/XMPFiles/source/FormatSupport/RIFF_Support.cpp
@@ -613,7 +613,7 @@ static void exportXMPtoBextChunk( RIFF_MetaHandler* handler, ValueChunk** bextCh
 	// prepare buffer, need to know CodingHistory size as the only variable
 	XMP_Int32 bextBufferSize = MIN_BEXT_SIZE - 8; // -8 because of header
 	std::string value;
-	if ( xmp->GetProperty( bextCodingHistory.ns, bextCodingHistory.prop, &value, kXMP_NoOptions ))
+	if ( xmp->GetProperty( bextCodingHistory.ns, bextCodingHistory.prop, &value, 0 ))
 	{
 		bextBufferSize += ((XMP_StringLen)value.size()) + 1 ; // add to size (and a trailing zero)
 	}
@@ -625,35 +625,35 @@ static void exportXMPtoBextChunk( RIFF_MetaHandler* handler, ValueChunk** bextCh
 
 	// grab props, write into buffer, remove from XMP ///////////////////////////
 	// bextDescription ------------------------------------------------
-	if ( xmp->GetProperty( bextDescription.ns, bextDescription.prop, &value, kXMP_NoOptions ) )
+	if ( xmp->GetProperty( bextDescription.ns, bextDescription.prop, &value, 0 ) )
 	{
 		setBextField( &value, (XMP_Uns8*) buffer, 0, 256 );
 		xmp->DeleteProperty( bextDescription.ns, bextDescription.prop)					;
 		chunkUsed = true;
 	}
 	// bextOriginator -------------------------------------------------
-	if ( xmp->GetProperty( bextOriginator.ns , bextOriginator.prop, &value, kXMP_NoOptions ) )
+	if ( xmp->GetProperty( bextOriginator.ns , bextOriginator.prop, &value, 0 ) )
 	{
 		setBextField( &value, (XMP_Uns8*) buffer, 256, 32 );
 		xmp->DeleteProperty( bextOriginator.ns , bextOriginator.prop );
 		chunkUsed = true;
 	}
 	// bextOriginatorRef ----------------------------------------------
-	if ( xmp->GetProperty( bextOriginatorRef.ns , bextOriginatorRef.prop, &value, kXMP_NoOptions ) )
+	if ( xmp->GetProperty( bextOriginatorRef.ns , bextOriginatorRef.prop, &value, 0 ) )
 	{
 		setBextField( &value, (XMP_Uns8*) buffer, 256+32, 32 );
 		xmp->DeleteProperty( bextOriginatorRef.ns , bextOriginatorRef.prop );
 		chunkUsed = true;
 	}
 	// bextOriginationDate --------------------------------------------
-	if ( xmp->GetProperty( bextOriginationDate.ns , bextOriginationDate.prop, &value, kXMP_NoOptions ) )
+	if ( xmp->GetProperty( bextOriginationDate.ns , bextOriginationDate.prop, &value, 0 ) )
 	{
 		setBextField( &value, (XMP_Uns8*) buffer, 256+32+32, 10 );
 		xmp->DeleteProperty( bextOriginationDate.ns , bextOriginationDate.prop );
 		chunkUsed = true;
 	}
 	// bextOriginationTime --------------------------------------------
-	if ( xmp->GetProperty( bextOriginationTime.ns , bextOriginationTime.prop, &value, kXMP_NoOptions ) )
+	if ( xmp->GetProperty( bextOriginationTime.ns , bextOriginationTime.prop, &value, 0 ) )
 	{
 		setBextField( &value, (XMP_Uns8*) buffer, 256+32+32+10, 8 );
 		xmp->DeleteProperty( bextOriginationTime.ns , bextOriginationTime.prop );
@@ -661,7 +661,7 @@ static void exportXMPtoBextChunk( RIFF_MetaHandler* handler, ValueChunk** bextCh
 	}
 	// bextTimeReference ----------------------------------------------
 	// thanx to friendly byte order, all 8 bytes can be written in one go:
-	if ( xmp->GetProperty( bextTimeReference.ns, bextTimeReference.prop, &value, kXMP_NoOptions ) )
+	if ( xmp->GetProperty( bextTimeReference.ns, bextTimeReference.prop, &value, 0 ) )
 	{
 		try
 		{
@@ -684,7 +684,7 @@ static void exportXMPtoBextChunk( RIFF_MetaHandler* handler, ValueChunk** bextCh
 	xmp->DeleteProperty( bextVersion.ns, bextVersion.prop );
 
 	// bextUMID -------------------------------------------------------
-	if ( xmp->GetProperty( bextUMID.ns, bextUMID.prop, &value, kXMP_NoOptions ) )
+	if ( xmp->GetProperty( bextUMID.ns, bextUMID.prop, &value, 0 ) )
 	{
 		std::string rawStr;
 
@@ -703,7 +703,7 @@ static void exportXMPtoBextChunk( RIFF_MetaHandler* handler, ValueChunk** bextCh
 	}
 
 	// bextCodingHistory ----------------------------------------------
-	if ( xmp->GetProperty( bextCodingHistory.ns, bextCodingHistory.prop, &value, kXMP_NoOptions ) )
+	if ( xmp->GetProperty( bextCodingHistory.ns, bextCodingHistory.prop, &value, 0 ) )
 	{
 		std::string ascii;
 		convertToASCII( value.data(), (XMP_StringLen) value.size() , &ascii, (XMP_StringLen) value.size() );

--- a/XMPFiles/source/PluginHandler/ModuleUtils.h
+++ b/XMPFiles/source/PluginHandler/ModuleUtils.h
@@ -16,7 +16,6 @@
 typedef HMODULE OS_ModuleRef;
 #elif XMP_MacBuild
 #include <CoreFoundation/CFBundle.h>
-#include <tr1/memory>
 typedef CFBundleRef OS_ModuleRef;
 #elif XMP_UNIXBuild
 #include <tr1/memory>

--- a/XMPFiles/source/PluginHandler/PluginManager.h
+++ b/XMPFiles/source/PluginHandler/PluginManager.h
@@ -17,6 +17,9 @@
 	#include <memory>
 	#include <functional>
 	#define XMP_SHARED_PTR std::shared_ptr
+#elif XMP_MacBuild
+	#include <memory>
+	#define XMP_SHARED_PTR std::shared_ptr
 #else
 	#define XMP_SHARED_PTR std::tr1::shared_ptr
 #endif

--- a/autogen.sh
+++ b/autogen.sh
@@ -13,16 +13,18 @@ fi
 builddir=`pwd`
 
 AUTOCONF=autoconf
-if test -x /usr/bin/glibtool ; then
-    LIBTOOL=glibtool
-else
+
+LIBTOOL=$(command -v glibtool)
+if [ -z "$LIBTOOL" ]; then
     LIBTOOL=libtool
 fi
-if test -x /usr/bin/glibtoolize ; then
-    LIBTOOLIZE=glibtoolize
-else
+
+LIBTOOLIZE=$(command -v glibtoolize)
+if [ -z "$LIBTOOLIZE" ]; then
     LIBTOOLIZE=libtoolize
 fi
+
+
 AUTOMAKE=automake
 ACLOCAL=aclocal
 

--- a/configure.ac
+++ b/configure.ac
@@ -178,7 +178,8 @@ fi
 case $build_vendor in
 	apple)
 		EXEMPI_PLATFORM_DEF=MAC_ENV
-		LDFLAGS="$LDFLAGS -framework CoreServices"
+		LDFLAGS="$LDFLAGS -framework CoreServices -stdlib=libc++"
+		CPPFLAGS="$CPPFLAGS -std=c++11 -stdlib=libc++"
 		;;
 	*)
 		EXEMPI_PLATFORM_DEF=UNIX_ENV
@@ -187,6 +188,7 @@ esac
 
 AC_SUBST(EXEMPI_PLATFORM_DEF)
 AM_CONDITIONAL(MAC_ENV, test x$EXEMPI_PLATFORM_DEF = xMAC_ENV)
+AM_CONDITIONAL(UNIX_ENV, test x$EXEMPI_PLATFORM_DEF = xUNIX_ENV)
 
 AM_CONDITIONAL(WITH_UNIT_TEST, test x$ENABLE_UNITTEST = xyes)
 

--- a/exempi/Makefile.am
+++ b/exempi/Makefile.am
@@ -63,7 +63,12 @@ libexempi_la_LIBADD = $(top_builddir)/source/libxmpcommon.la \
 	$(top_builddir)/XMPCore/source/libXMPCore.la \
 	$(top_builddir)/XMPFiles/source/libXMPFiles.la \
 	$(top_builddir)/third-party/zuid/interfaces/libmd5.la \
-	-lexpat -lz -ldl -lrt
+	-lexpat -lz -ldl
+
+if UNIX_ENV
+libexempi_la_LIBADD += -lrt
+endif
+
 libexempi_la_LDFLAGS = -version-info @EXEMPI_VERSION_INFO@
 
 if HAVE_SYMBOLS_FILE

--- a/public/include/XMP_Environment.h
+++ b/public/include/XMP_Environment.h
@@ -185,4 +185,15 @@
 	#define XMP_PRIVATE XMP_HELPER_DLL_PRIVATE
 #endif
 
+// Emulate nullptr for GCC < 4.6.0
+#if defined __GNUC__ && !defined __clang__ && (__GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 6))
+const class nullptr_t {
+ public:
+  template<class T> operator T*() const { return 0; }
+  template<class C, class T> operator T C::*() const { return 0; }
+ private:
+  void operator&() const;
+} nullptr = {};
+#endif
+
 #endif  // __XMP_Environment_h__

--- a/samples/source/Makefile.am
+++ b/samples/source/Makefile.am
@@ -48,9 +48,13 @@ AM_CXXFLAGS = -fexceptions -funsigned-char -fPIC \
 AM_CPPFLAGS = -D@EXEMPI_PLATFORM_DEF@=1 -D_FILE_OFFSET_BITS=64
 XMPLIBS = $(top_builddir)/XMPCore/source/libXMPCore.la \
 	$(top_builddir)/XMPFiles/source/libXMPFiles.la \
-	$(top_builddir)/source/libxmpcommon.la -lexpat -lz -lrt \
+	$(top_builddir)/source/libxmpcommon.la -lexpat -lz \
 	$(top_builddir)/third-party/zuid/interfaces/libmd5.la \
 	-ldl
+
+if UNIX_ENV
+XMPLIBS += -lrt
+endif
 
 INCLUDES = -I$(top_srcdir)/public/include -I$(top_srcdir)
 


### PR DESCRIPTION
I had to make a few fixes in order to get Exempi 2.4.0 to build on OS X 10.11, and a few other fixes to get builds working on CentOS 6. These included:
- Check for `glibtool` and `glibtoolize` in the full `PATH`, not just `/usr/bin` (because with Homebrew on mac these get installed in `/usr/local`)
- Fix type mismatch in calls to `XMPMeta::GetProperty()`<sup><b>1</b></sup>
- Only link against librt on unix environments (the calls to `clock_gettime()` are already inside `#if UNIX_ENV` directives) since it is unavailable on mac
- On mac, add `-stdlib=libc++` to `CPPFLAGS` and `LDFLAGS`, and `-std=c++11` to `CPPFLAGS` so that `std::unique_ptr` works
- Change `#include <tr1/memory>` to `#include <memory>` on mac (because the former does not work with `-stdlib=libc++`)
- Emulate `nullptr` for GCC < 4.6.0
- Fix a syntax error in `ExpatAdapter.cpp` when `#if BanAllEntityUsage` is true (as it is in the Fedora RPM spec file, because of [#888765](https://bugzilla.redhat.com/show_bug.cgi?id=888765))

<sup><b>1</b></sup> Although `kXMP_NoOptions` equals `0`, and thus shouldn't make a difference whether it is a pointer or not, clang complains about the type mismatch with `cannot initialize a parameter of type 'XMP_OptionBits *' (aka 'unsigned int *') with an rvalue of type 'XMP_OptionBits' (aka 'unsigned int')`. I used `0` rather than `nullptr` for consistency with the way `XMPMeta::GetProperty()` is called elsewhere.
