### PR TITLE
Fix CVE-2018-12648

### DIFF
--- a/XMPFiles/source/FormatSupport/WEBP_Support.cpp
+++ b/XMPFiles/source/FormatSupport/WEBP_Support.cpp
@@ -160,9 +160,11 @@ bool VP8XChunk::xmp()
 }
 void VP8XChunk::xmp(bool hasXMP)
 {
-    XMP_Uns32 flags = GetLE32(&this->data[0]);
-    flags ^= (-hasXMP ^ flags) & (1 << XMP_FLAG_BIT);
-    PutLE32(&this->data[0], flags);
+    if(&this->data[0] != NULL){
+        XMP_Uns32 flags = GetLE32(&this->data[0]);
+        flags ^= (-hasXMP ^ flags) & (1 << XMP_FLAG_BIT);
+        PutLE32(&this->data[0], flags);
+    }
 }
 
 Container::Container(WEBP_MetaHandler* handler) : Chunk(NULL, handler)


### PR DESCRIPTION
The WEBP::GetLE32 function in
XMPFiles/source/FormatSupport/WEBP_Support.hpp in Exempi 2.4.5 has a
NULL pointer dereference.

https://bugs.freedesktop.org/show_bug.cgi?id=106981

Signed-off-by: Victor Rodriguez <victor.rodriguez.bahena@intel.com>